### PR TITLE
Convert grid elements position and scale to scss - PR

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,4 +26,4 @@ reportWebVitals();
 
 console.log('setter json', parseJsonToTsx(SetJsonStyle({ color: 'red' })));
 
-console.log('Sass parseado:', parseJsonToScss(testJson));
+console.log('Sass parseado:\n', parseJsonToScss(testJson));

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import { IndexedDB } from './lib/axios/indexeddb/IndexedDB';
 import apiDefinitionYml from './config/api.json';
 import { SetJsonStyle } from './utils/SetJsonStyle';
 import { parseJsonToTsx } from './utils/parser/JsonToTsx';
+import { parseJsonToScss, testJson } from './utils/parser/JsonToScss';
 
 const store = configureAppStore({});
 
@@ -24,3 +25,5 @@ root.render(<Provider store={store}>{<App />}</Provider>);
 reportWebVitals();
 
 console.log('setter json', parseJsonToTsx(SetJsonStyle({ color: 'red' })));
+
+console.log('Sass parseado:', parseJsonToScss(testJson));

--- a/src/utils/parser/JsonToScss.tsx
+++ b/src/utils/parser/JsonToScss.tsx
@@ -1,0 +1,76 @@
+import { Layout, TsxObj } from './TsxToJson';
+
+/**
+ * Parsea el contenido de un .tsx a JSON.
+ *
+ *
+ * @param input - String con todo el código de un archivo tsx y devuelve
+ * @returns JSON/objeto de tipo TsxObj
+ *
+ */
+function parseGridLayoutChildren(children: Layout[]): string {
+  let result: string = '';
+
+  children.forEach((child) => {
+    result += `
+        & .${child.uuid}{
+            grid-row: ${child.x} / span ${child.w};
+            grid-row: ${child.y} / span ${child.h};
+        }
+    `;
+  });
+  return result;
+}
+
+export function parseJsonToScss(input: TsxObj): string {
+  let result: string = '';
+  let parentClass: string | undefined;
+
+  const component = input.component?.returnedContent;
+  if (typeof component === 'object') {
+    parentClass = component.dom.attributes?.find(
+      (attr) => attr.key === 'className'
+    )?.value;
+
+    if (parentClass) {
+      result += `.${parentClass} {`;
+
+      result += parseGridLayoutChildren(
+        component?.dom.children.map(
+          (child) =>
+            (typeof child === 'object' &&
+              'dom' in child &&
+              child.dom.layout) || { uuid: '', x: 0, y: 0, h: 0, w: 0 }
+        )
+      );
+    }
+  }
+
+  return result;
+}
+
+export function parseJsonToScss2(input: TsxObj): string {
+  const component = input.component?.returnedContent;
+  if (typeof component !== 'object') {
+    return '';
+  }
+
+  const parentClass = component.dom.attributes?.find(
+    (attr) => attr.key === 'className'
+  )?.value;
+  if (!parentClass) {
+    return '';
+  }
+
+  let result = `.${parentClass} {\n`;
+
+  result += parseGridLayoutChildren(
+    component?.dom.children
+      .map((child) => 'dom' in child && child.dom.layout)
+      .filter((child) => child !== undefined) as Layout[]
+  );
+
+  result += '\n}\n';
+
+  return result;
+}

--- a/src/utils/parser/JsonToScss.tsx
+++ b/src/utils/parser/JsonToScss.tsx
@@ -1,13 +1,5 @@
 import { Layout, TsxObj } from './TsxToJson';
 
-/**
- * Parsea el contenido de un .tsx a JSON.
- *
- *
- * @param input - String con todo el código de un archivo tsx y devuelve
- * @returns JSON/objeto de tipo TsxObj
- *
- */
 function parseGridLayoutChildren(children: Layout[]): string {
   let result: string = '';
 
@@ -22,44 +14,28 @@ function parseGridLayoutChildren(children: Layout[]): string {
   return result;
 }
 
+/**
+ * Parsea el JSON del componente a formato SASS. Utiliza el layout de los hijos para generar el grid.
+ *
+ *
+ * @param input - JSON (de tipo TsxObj) del componente a parsear
+ * @returns string con los estilos del componente en formato SASS.
+ *
+ */
 export function parseJsonToScss(input: TsxObj): string {
-  let result: string = '';
-  let parentClass: string | undefined;
-
-  const component = input.component?.returnedContent;
-  if (typeof component === 'object') {
-    parentClass = component.dom.attributes?.find(
-      (attr) => attr.key === 'className'
-    )?.value;
-
-    if (parentClass) {
-      result += `.${parentClass} {`;
-
-      result += parseGridLayoutChildren(
-        component?.dom.children.map(
-          (child) =>
-            (typeof child === 'object' &&
-              'dom' in child &&
-              child.dom.layout) || { uuid: '', x: 0, y: 0, h: 0, w: 0 }
-        )
-      );
-    }
-  }
-
-  return result;
-}
-
-export function parseJsonToScss2(input: TsxObj): string {
   const component = input.component?.returnedContent;
   if (typeof component !== 'object') {
-    return '';
+    throw new Error('El elemento padre necesita ser un TagObj');
   }
 
   const parentClass = component.dom.attributes?.find(
     (attr) => attr.key === 'className'
   )?.value;
+
   if (!parentClass) {
-    return '';
+    throw new Error(
+      'El elemento padre necesita un className para ser identificado'
+    );
   }
 
   let result = `.${parentClass} {\n`;

--- a/src/utils/parser/JsonToScss.tsx
+++ b/src/utils/parser/JsonToScss.tsx
@@ -1,6 +1,6 @@
 import { Layout, TsxObj } from './TsxToJson';
 
-function parseGridLayoutChildren(children: Layout[]): string {
+function parseLayoutChildren(children: Layout[]): string {
   let result: string = '';
 
   children.forEach((child) => {
@@ -15,7 +15,8 @@ function parseGridLayoutChildren(children: Layout[]): string {
 }
 
 /**
- * Parsea el JSON del componente a formato SASS. Utiliza el layout de los hijos para generar el grid.
+ * Parsea el JSON del componente a formato SASS.
+ * Utiliza el layout de los hijos para generar el grid.
  *
  *
  * @param input - JSON (de tipo TsxObj) del componente a parsear
@@ -38,9 +39,14 @@ export function parseJsonToScss(input: TsxObj): string {
     );
   }
 
-  let result = `.${parentClass} {\n`;
+  let result = `.${parentClass} {
+      display: grid;
+      grid-template-columns: repeat(12, 1fr);
+      grid-auto-rows: 30px;
+      grid-gap: 0px;
+    \n`;
 
-  result += parseGridLayoutChildren(
+  result += parseLayoutChildren(
     component?.dom.children
       .map((child) => 'dom' in child && child.dom.layout)
       .filter((child) => child !== undefined) as Layout[]
@@ -50,3 +56,104 @@ export function parseJsonToScss(input: TsxObj): string {
 
   return result;
 }
+
+export const testJson = {
+  imports: [
+    //eslint-disable-next-line
+    "import React, { useState } from 'react'",
+    //eslint-disable-next-line
+    "import { Header } from 'src/components/header/Header'",
+    //eslint-disable-next-line
+    "import { WebNavBar } from 'src/components/webNavBar/WebNavBar'",
+    //eslint-disable-next-line
+    "import './notFound.scss'",
+  ],
+  component: {
+    path: './src/components/Component',
+    name: 'NotFound',
+    args: [
+      {
+        name: '',
+        optional: false,
+      },
+    ],
+    returnedContent: {
+      dom: {
+        type: 'div',
+        attributes: [
+          {
+            key: 'className',
+            value: 'notFound',
+          },
+        ],
+        children: [
+          {
+            dom: {
+              type: 'Header',
+              layout: {
+                uuid: 'sdpfosslsdlsdpldpsdflsdpfldsfp2309430493',
+                x: 3,
+                y: 1,
+                w: 2,
+                h: 2,
+              },
+              attributes: [],
+              children: [],
+            },
+          },
+          {
+            dom: {
+              type: 'div',
+              attributes: [],
+              layout: {
+                uuid: 'sdpfosslsdlsdpldpsdflsdpfldsfp2309430493',
+                x: 3,
+                y: 1,
+                w: 2,
+                h: 2,
+              },
+              children: [
+                {
+                  dom: {
+                    type: 'h1',
+                    attributes: [],
+                    children: [
+                      {
+                        text: '404 - Page Not Found',
+                      },
+                    ],
+                  },
+                },
+                {
+                  dom: {
+                    type: 'p',
+                    attributes: [],
+                    children: [
+                      {
+                        text: 'Sorry, the page does not exist (by the moment)',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            dom: {
+              type: 'WebNavBar',
+              attributes: [],
+              layout: {
+                uuid: 'sdpfosslsdlsdpldpsdflsdpfldsfp2309430493',
+                x: 3,
+                y: 1,
+                w: 2,
+                h: 2,
+              },
+              children: [],
+            },
+          },
+        ],
+      },
+    },
+  },
+};

--- a/src/utils/parser/JsonToScss.tsx
+++ b/src/utils/parser/JsonToScss.tsx
@@ -39,6 +39,8 @@ export function parseJsonToScss(input: TsxObj): string {
     );
   }
 
+  // Ajustado a los valores por defecto del grid de drag-and-drop:
+  // (12 columnas y filas de 30px)
   let result = `.${parentClass} {
       display: grid;
       grid-template-columns: repeat(12, 1fr);

--- a/src/utils/parser/TsxToJson.ts
+++ b/src/utils/parser/TsxToJson.ts
@@ -1,7 +1,7 @@
 // Esta versión de eslint tiene un bug para typescript: dice que DomElementType no se utiliza.
 /* eslint-disable*/
 //TYPES
-type TsxObj = {
+export type TsxObj = {
   imports: string[];
   component: FunctionObj;
   functions?: FunctionObj[];
@@ -23,7 +23,7 @@ type TextObj = {
   text: string;
 };
 
-type TagObj = {
+export type TagObj = {
   dom: {
     type: string;
     attributes?: KeyValue[];
@@ -32,7 +32,7 @@ type TagObj = {
   };
 };
 
-type Layout = {
+export type Layout = {
   uuid: string;
   x: number;
   y: number;


### PR DESCRIPTION
- utils/parser/JsonTOScss.tsx:
Exporta la función `parseJsonToScss` para parsear a scss. Recibe el json (formato TsxObj) y devuelve un string con el contenido del scss que deberá ser generado.

- index.js:
Añadido console.log de un ejemplo.
